### PR TITLE
Fix comment validator not accepting null for parent_id

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -203,7 +203,7 @@ app.get('/posts/:id/comments', (req, res) => {
 // Create a Comment for a Post
 app.post('/posts/:id/comments',[
     body('author',INVALID_VALUE_MESSAGE).exists({checkNull: true}),
-    body('parent_id',INVALID_VALUE_MESSAGE).isNumeric(),
+    body('parent_id',INVALID_VALUE_MESSAGE).custom((value) => Number.isInteger(value) || value === null),
     body('date', INVALID_VALUE_MESSAGE).isString(),
     body('body',INVALID_VALUE_MESSAGE).exists({checkNull: true}),
     checkValidation


### PR DESCRIPTION
As specified in the [docs](https://hezardastan-ir.github.io/frontend-course/course/advanced-react.html#%D8%A7%D8%B1%D8%B3%D8%A7%D9%84-comment),  parent_id can be `null` or `number`. But the server validator only accepts `number`, and because of that, posting comments that are not replies fail. This custom validator accepts both